### PR TITLE
WTEL-9447: Fix destinations sort

### DIFF
--- a/store/sqlstore/cc_member_store.go
+++ b/store/sqlstore/cc_member_store.go
@@ -176,6 +176,10 @@ func getMemberSortClause(sort string) string {
         return fmt.Sprintf("order by coalesce((select agn.name from call_center.cc_agent a left join directory.wbt_user agn on agn.id = a.user_id where a.id = m.agent_id), '') %s", direction)
     }
 
+    if field == "communications" {
+        return fmt.Sprintf("order by (m.communications->0->>'destination') %s", direction)
+    }
+
     return GetOrderBy("cc_member", sort)
 }
 


### PR DESCRIPTION
## Опис
Виправлено сортування за колонкою «Destinations» у списку абонентів черги.

## Причина
Універсальний GetOrderBy для jsonb-колонок сортує за ->>'name', очікуючи структуру лукапа {id, name}. У cc_member.communications елементи мають іншу схему - значення лежить у полі destination, а name на верхньому рівні відсутнє. Тому вираз завжди повертав NULL, і порядок рядків не змінювався.

## Рішення
Додано спец-кейс у getMemberSortClause (за аналогією з agent), який сортує за m.communications->0->>'destination'.