### PR TITLE
WTEL-9448: Default sort by created_at DESC

### DIFF
--- a/model/cc_audit_form.go
+++ b/model/cc_audit_form.go
@@ -68,7 +68,7 @@ func (q *AuditForm) Patch(p *AuditFormPatch) {
 }
 
 func (AuditForm) DefaultOrder() string {
-	return "name"
+	return "-created_at"
 }
 
 func (AuditForm) AllowFields() []string {

--- a/model/cc_quick_reply.go
+++ b/model/cc_quick_reply.go
@@ -36,7 +36,7 @@ func (p QuickReply) AllowFields() []string {
 }
 
 func (QuickReply) DefaultOrder() string {
-	return "-name"
+	return "-created_at"
 }
 
 func (QuickReply) DefaultFields() []string {

--- a/model/flow.go
+++ b/model/flow.go
@@ -35,7 +35,7 @@ type SearchRoutingSchemaTag struct {
 }
 
 func (RoutingSchema) DefaultOrder() string {
-	return "id"
+	return "-created_at"
 }
 
 func (a RoutingSchema) AllowFields() []string {

--- a/store/sqlstore/cc_audit_form.go
+++ b/store/sqlstore/cc_audit_form.go
@@ -94,6 +94,12 @@ func (s SqlAuditFormStore) GetAllPage(ctx context.Context, domainId int64, searc
 		"TeamUserID": search.TeamUserID,
 	}
 
+	originalSort := search.Sort
+	if search.TeamUserID != nil && search.Sort == "" {
+		search.Sort = "case when team_ids && array(select a.team_id from call_center.cc_agent a where a.user_id = :TeamUserID::int8 and a.team_id notnull) then 0 else 1 end asc,name asc"
+		f["TeamUserID"] = *search.TeamUserID
+	}
+
 	err := s.ListQuery(ctx, &list, search.ListRequest,
 		`domain_id = :DomainId
 				and (:Q::varchar isnull or (name ilike :Q::varchar or description ilike :Q::varchar ))
@@ -116,6 +122,8 @@ func (s SqlAuditFormStore) GetAllPage(ctx context.Context, domainId int64, searc
 		return nil, model.NewCustomCodeError("store.sql_audit_form.get_all.app_error", err.Error(), extractCodeFromErr(err))
 	}
 
+	search.Sort = originalSort
+
 	return list, nil
 }
 
@@ -133,6 +141,12 @@ func (s SqlAuditFormStore) GetAllPageByGroup(ctx context.Context, domainId int64
 		"Editable":   search.Editable,
 		"Question":   model.ReplaceWebSearch(search.Question),
 		"TeamUserID": search.TeamUserID,
+	}
+
+	originalSort := search.Sort
+	if search.TeamUserID != nil && search.Sort == "" {
+		search.Sort = "case when team_ids && array(select a.team_id from call_center.cc_agent a where a.user_id = :TeamUserID::int8 and a.team_id notnull) then 0 else 1 end asc,name asc"
+		f["TeamUserID"] = *search.TeamUserID
 	}
 
 	err := s.ListQuery(ctx, &list, search.ListRequest,
@@ -153,13 +167,15 @@ func (s SqlAuditFormStore) GetAllPageByGroup(ctx context.Context, domainId int64
 				and (
 					exists(select 1
 					  from call_center.cc_audit_form_acl
-					  where call_center.cc_audit_form_acl.dc = t.domain_id and call_center.cc_audit_form_acl.object = t.id
+					  where call_center.cc_audit_form_acl.dc = t.domain_id and call_center.cc_audit_form_acl.object = t.id 
 						and call_center.cc_audit_form_acl.subject = any(:Groups::int[]) and call_center.cc_audit_form_acl.access&:Access = :Access)
 		  		)`,
 		model.AuditForm{}, f)
 	if err != nil {
 		return nil, model.NewCustomCodeError("store.sql_audit_form.get_all.app_error", err.Error(), extractCodeFromErr(err))
 	}
+
+	search.Sort = originalSort
 
 	return list, nil
 }

--- a/store/sqlstore/cc_audit_form.go
+++ b/store/sqlstore/cc_audit_form.go
@@ -94,12 +94,6 @@ func (s SqlAuditFormStore) GetAllPage(ctx context.Context, domainId int64, searc
 		"TeamUserID": search.TeamUserID,
 	}
 
-	originalSort := search.Sort
-	if search.TeamUserID != nil && search.Sort == "" {
-		search.Sort = "case when team_ids && array(select a.team_id from call_center.cc_agent a where a.user_id = :TeamUserID::int8 and a.team_id notnull) then 0 else 1 end asc,name asc"
-		f["TeamUserID"] = *search.TeamUserID
-	}
-
 	err := s.ListQuery(ctx, &list, search.ListRequest,
 		`domain_id = :DomainId
 				and (:Q::varchar isnull or (name ilike :Q::varchar or description ilike :Q::varchar ))
@@ -122,8 +116,6 @@ func (s SqlAuditFormStore) GetAllPage(ctx context.Context, domainId int64, searc
 		return nil, model.NewCustomCodeError("store.sql_audit_form.get_all.app_error", err.Error(), extractCodeFromErr(err))
 	}
 
-	search.Sort = originalSort
-
 	return list, nil
 }
 
@@ -141,12 +133,6 @@ func (s SqlAuditFormStore) GetAllPageByGroup(ctx context.Context, domainId int64
 		"Editable":   search.Editable,
 		"Question":   model.ReplaceWebSearch(search.Question),
 		"TeamUserID": search.TeamUserID,
-	}
-
-	originalSort := search.Sort
-	if search.TeamUserID != nil && search.Sort == "" {
-		search.Sort = "case when team_ids && array(select a.team_id from call_center.cc_agent a where a.user_id = :TeamUserID::int8 and a.team_id notnull) then 0 else 1 end asc,name asc"
-		f["TeamUserID"] = *search.TeamUserID
 	}
 
 	err := s.ListQuery(ctx, &list, search.ListRequest,
@@ -167,15 +153,13 @@ func (s SqlAuditFormStore) GetAllPageByGroup(ctx context.Context, domainId int64
 				and (
 					exists(select 1
 					  from call_center.cc_audit_form_acl
-					  where call_center.cc_audit_form_acl.dc = t.domain_id and call_center.cc_audit_form_acl.object = t.id 
+					  where call_center.cc_audit_form_acl.dc = t.domain_id and call_center.cc_audit_form_acl.object = t.id
 						and call_center.cc_audit_form_acl.subject = any(:Groups::int[]) and call_center.cc_audit_form_acl.access&:Access = :Access)
 		  		)`,
 		model.AuditForm{}, f)
 	if err != nil {
 		return nil, model.NewCustomCodeError("store.sql_audit_form.get_all.app_error", err.Error(), extractCodeFromErr(err))
 	}
-
-	search.Sort = originalSort
 
 	return list, nil
 }


### PR DESCRIPTION
## Зміни
Оновлено `DefaultOrder()` у трьох моделях на `-created_at`:
- `RoutingSchema` (Admin → Routing → Flow Schemas) - було `id`
- `QuickReply` (Admin → Lookups → Quick replies) - було `-name`
- `AuditForm` (Audit → Scorecards) - було `name`

Також прибрано override у `SqlAuditFormStore.GetAllPage` та `GetAllPageByGroup`, який при `TeamUserID != nil && Sort == ""` примусово сортував за `team_ids, name`. Тепер при порожньому `Sort` скрізь застосовується єдина логіка через `DefaultOrder()`.
