### PR TITLE
WTEL-9282: Auto-logout agent on websocket disconnect

### DIFF
--- a/app/web_conn.go
+++ b/app/web_conn.go
@@ -58,6 +58,7 @@ type WebConn struct {
 	mx                 sync.RWMutex
 	ip                 string
 	lastLatencyTime    atomic.Int64
+	agentId            atomic.Int64
 	log                *wlog.Logger
 	logMx              sync.RWMutex
 	Ctx                context.Context
@@ -161,6 +162,14 @@ func (wc *WebConn) SetLastLatencyTime(new int64) int64 {
 	t := wc.lastLatencyTime.Load()
 	wc.lastLatencyTime.Store(new)
 	return t
+}
+
+func (wc *WebConn) GetAgentId() int64 {
+	return wc.agentId.Load()
+}
+
+func (wc *WebConn) SetAgentId(id int64) {
+	wc.agentId.Store(id)
 }
 
 func (wc *WebConn) Close() {

--- a/app/web_hub.go
+++ b/app/web_hub.go
@@ -128,6 +128,26 @@ func (wh *Hub) start() {
 
 			wlog.Debug("deregister", wlog.Int("count", len(connections.ForUser(webCon.UserId))))
 
+			if agentId := webCon.GetAgentId(); agentId != 0 {
+				stillOnline := false
+				for _, other := range connections.ForUser(webCon.UserId) {
+					if other.GetAgentId() == agentId {
+						stillOnline = true
+						break
+					}
+				}
+				if !stillOnline {
+					domainId := webCon.DomainId
+					log := webCon.Log()
+					go func() {
+						if err := wh.app.LogoutAgent(domainId, agentId); err != nil {
+							log.Warn("auto logout agent on disconnect failed",
+								wlog.Int64("agent_id", agentId), wlog.Err(err))
+						}
+					}()
+				}
+			}
+
 		case msg := <-wh.domainQueue.Events():
 			candidates := connections.ForUser(msg.UserId)
 			for _, webCon := range candidates {

--- a/wsapi/agent.go
+++ b/wsapi/agent.go
@@ -75,6 +75,8 @@ func (api *API) onlineAgent(ctx context.Context, conn *app.WebConn, req *model.W
 		return nil, err
 	}
 
+	conn.SetAgentId(int64(agentId))
+
 	res := make(map[string]interface{})
 	return res, nil
 }
@@ -96,6 +98,8 @@ func (api *API) offlineAgent(ctx context.Context, conn *app.WebConn, req *model.
 	if err != nil {
 		return nil, err
 	}
+
+	conn.SetAgentId(0)
 
 	res := make(map[string]interface{})
 	return res, nil


### PR DESCRIPTION
## Проблема
Оператор відображався онлайн в адмінці навіть коли в нього закрита вкладка Workspace або він застряг на модалці дозволів. Engine при розриві websocket'у тільки прибирав з'єднання з індексу хабу, але ніколи не повідомляв call_center про офлайн.

## Вирішення
Engine тепер сам викликає `LogoutAgent` при розриві останнього websocket'у юзера, на якому був активний агент. Для цього на `WebConn` додано трекінг `agentId`, який виставляється після успішного `cc_agent_online` і скидається після `cc_agent_offline`. У циклі `Hub.start` на `unregister` перевіряється: якщо в інших з'єднаннях того ж юзера немає цього `agentId`, в окремій горутині стріляє `LogoutAgent`.

