### PR TITLE
WTEL-9468: Handle no-prefix sort for from/to

### DIFF
--- a/store/sqlstore/call_store.go
+++ b/store/sqlstore/call_store.go
@@ -36,7 +36,7 @@ func rewriteCallSort(sort string) string {
 	}
 	dir, field := orderBy(s)
 	if dir == "" {
-		return sort
+		field = s
 	}
 	nulls := "NULLS LAST"
 	if strings.EqualFold(dir, "desc") {


### PR DESCRIPTION
## Зміни
У хелпері `rewriteCallSort` ранній вихід `if dir == "" { return sort }` пропускав значення з порожнім напрямком далі у `GetOrderBy`.

Замість раннього виходу тепер тримаємо напрямок порожнім (Postgres за замовчуванням обробляє це як ASC).

