### PR TITLE
WTEL-9610: Improve AMD Result filtering logic

### DIFF
--- a/model/search_list.go
+++ b/model/search_list.go
@@ -145,6 +145,43 @@ func ReplaceWebSearch(s string) *string {
 	return nil
 }
 
+var amdResultAliases = map[string][]string{
+	"NOTSURE":   {"NOTSURE"},
+	"HUMAN":     {"HUMAN", "human"},
+	"MACHINE":   {"MACHINE"},
+	"CANCEL":    {"CANCEL", "cancelled"},
+	"SILENCE":   {"SILENCE", "silence"},
+	"VOICEMAIL": {"VOICEMAIL", "voicemail"},
+	"RINGING":   {"RINGING", "ringback"},
+	"TIMEOUT":   {"TIMEOUT", "timeout"},
+}
+
+func ExpandAmdResult(values []string) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(values)*2)
+	seen := make(map[string]struct{})
+	add := func(v string) {
+		if _, ok := seen[v]; ok {
+			return
+		}
+		seen[v] = struct{}{}
+		out = append(out, v)
+	}
+	for _, v := range values {
+		if aliases, ok := amdResultAliases[strings.ToUpper(v)]; ok {
+			for _, a := range aliases {
+				add(a)
+			}
+			continue
+		}
+		add(strings.ToUpper(v))
+		add(strings.ToLower(v))
+	}
+	return out
+}
+
 func (l *ListRequest) GetRegExpQ() *string {
 	return GetRegExpQ(l.Q)
 }

--- a/store/sqlstore/call_store.go
+++ b/store/sqlstore/call_store.go
@@ -378,7 +378,7 @@ func (s SqlCallStore) GetHistory(ctx context.Context, domainId int64, search *mo
 		and (:Ids::uuid[] isnull or id = any(:Ids))
 		and (:TransferFromIds::uuid[] isnull or transfer_from = any(:TransferFromIds))
 		and (:TransferToIds::uuid[] isnull or transfer_to = any(:TransferToIds))
-		and (:AmdResult::varchar[] isnull or amd_result = any(upper(:AmdResult::text)::varchar[]) or amd_ai_result = any(lower(:AmdResult::text)::varchar[]))
+		and (:AmdResult::varchar[] isnull or amd_result = any(:AmdResult::varchar[]) or amd_ai_result = any(:AmdResult::varchar[]))
 		and (:QueueIds::int[] isnull or (queue_id = any(:QueueIds) or queue_ids && :QueueIds::int[]) )
 		and (:TeamIds::int[] isnull or (team_id = any(:TeamIds) or team_ids && :TeamIds::int[]) )
 		and (:AgentIds::int[] isnull or ( agent_ids && :AgentIds::int[]) )
@@ -477,7 +477,7 @@ func (s SqlCallStore) GetHistory(ctx context.Context, domainId int64, search *mo
 		"TransferToIds":    pq.Array(search.TransferToIds),
 		"DependencyIds":    pq.Array(search.DependencyIds),
 		"Tags":             pq.Array(search.Tags),
-		"AmdResult":        pq.Array(search.AmdResult),
+		"AmdResult":        pq.Array(model.ExpandAmdResult(search.AmdResult)),
 		"Variables":        search.Variables.ToSafeJson(),
 		"HasTranscript":    search.HasTranscript,
 		"Fts":              search.Fts,
@@ -547,7 +547,7 @@ func (s SqlCallStore) GetHistoryByGroups(ctx context.Context, domainId, userSupe
 		"TransferToIds":    pq.Array(search.TransferToIds),
 		"DependencyIds":    pq.Array(search.DependencyIds),
 		"Tags":             pq.Array(search.Tags),
-		"AmdResult":        pq.Array(search.AmdResult),
+		"AmdResult":        pq.Array(model.ExpandAmdResult(search.AmdResult)),
 		"Groups":           pq.Array(groups),
 		"Access":           auth_manager.PERMISSION_ACCESS_READ.Value(),
 		"UserSupervisorId": userSupervisorId,
@@ -592,7 +592,7 @@ func (s SqlCallStore) GetHistoryByGroups(ctx context.Context, domainId, userSupe
 	and (:Ids::uuid[] isnull or id = any(:Ids))
 	and (:TransferFromIds::uuid[] isnull or transfer_from = any(:TransferFromIds))
 	and (:TransferToIds::uuid[] isnull or transfer_to = any(:TransferToIds))
-	and (:AmdResult::varchar[] isnull or amd_result = any(upper(:AmdResult::text)::varchar[]) or amd_ai_result = any(lower(:AmdResult::text)::varchar[]))
+	and (:AmdResult::varchar[] isnull or amd_result = any(:AmdResult::varchar[]) or amd_ai_result = any(:AmdResult::varchar[]))
 	and (:QueueIds::int[] isnull or (queue_id = any(:QueueIds) or queue_ids && :QueueIds::int[]) )
 	and (:TeamIds::int[] isnull or (team_id = any(:TeamIds) or team_ids && :TeamIds::int[]) )
 	and (:AgentIds::int[] isnull or ( agent_ids && :AgentIds::int[]) )


### PR DESCRIPTION
## Зміни

- Додано `ExpandAmdResult` та карту `amdResultAliases` у `search_list.go`: значення
  фільтра AMD Result розгортається у повний набір збережених результатів (`CANCEL`
  у `CANCEL`, `cancelled`; `RINGING` у `RINGING`, `ringback` тощо).