### PR TITLE
WTEL-9598: Require team field on agent validation

### DIFF
--- a/model/cc_agent.go
+++ b/model/cc_agent.go
@@ -396,6 +396,9 @@ func (a *Agent) IsValid() AppError {
 	if a.ProgressiveCount < 1 {
 		return NewBadRequestError("model.Agent.valid.ProgressiveCount", "The call count should be more or equal 1")
 	}
+	if a.Team == nil || a.Team.Id == 0 {
+		return NewBadRequestError("model.Agent.valid.Team", "Team is required")
+	}
 	return nil //TODO
 }
 


### PR DESCRIPTION
## Проблема
У Supervisor > Agents > General tab поле "Команда" можна було очистити і зберегти оператора без команди. Через це оператор втрачав можливість користуватися дзвінками контакт-центру.

## Вирішення
Додано серверну валідацію обов'язковості поля `team` у методі `Agent.IsValid()`. Цей метод викликається з усіх трьох RPC, що пишуть агента (`CreateAgent`, `UpdateAgent`, `PatchAgent`).