### PR TITLE
WTEL-9623: Prevent nil pointer panic in PauseAgent

### DIFF
--- a/model/error.go
+++ b/model/error.go
@@ -40,5 +40,9 @@ func NewCustomCodeError(id string, details string, code int) AppError {
 }
 
 func AppErrorFromJson(js string) AppError {
-	return werror.AppErrorFromJson(js)
+	appErr := werror.AppErrorFromJson(js)
+	if appErr == nil {
+		return nil
+	}
+	return appErr
 }


### PR DESCRIPTION
## Проблема
Сервіс `engine` падав з `panic: runtime error: invalid memory address or nil pointer dereference` (SIGSEGV) під час зміни статусу агента (`UpdateAgentStatus` -> `PauseAgent`).

Причина - баг Go "typed nil in interface". Функція `werror.AppErrorFromJson` повертає nil-вказівник `*ApplicationError`, коли gRPC-помилка від call-center сервісу не є валідним JSON-ом `ApplicationError` (або не містить поля `id`). Цей nil-вказівник загортався в інтерфейс `model.AppError`, утворюючи **не-nil інтерфейс із nil-значенням**. Через це перевірка `if appErr = nil` у `PauseAgent` проходила, а виклик `SetStatusCode` розіменовував nil-receiver і викликав паніку.
  
## Вирішення
Централізовано виправлено `AppErrorFromJson` у пакеті `model`: якщо `werror` повернув nil-вказівник, повертаємо явний `nil`, що дає справжній nil-інтерфейс. Завдяки цьому наявна перевірка `if appErr != nil` у `PauseAgent` починає працювати коректно і логіка йде у безпечний fallback `NewBadRequestError` без паніки.

## Зміни
- Виправлено `AppErrorFromJson` у `model/error.go` - явне повернення `nil` замість nil-вказівника, загорнутого в інтерфейс