### PR TITLE
chore: backport debian maintainer scripts and packaging to v26.04

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -48,14 +48,14 @@ jobs:
       version: ${{ needs.prepare.outputs.version }}
       version-build: ${{ github.run_number }}
       prerelease: dev~pr${{ github.event.pull_request.number }}
-      package-name: ${{ vars.SERVICE_NAME }}
+      package-name: webitel-engine
       package-description: ${{ github.event.repository.description }}
       package-contents: |
-        src=deploy/systemd/${{ vars.SERVICE_NAME }}.service dst=/etc/systemd/system/${{ vars.SERVICE_NAME }}.service type=config
+        src=deploy/systemd/webitel-engine.service dst=/etc/systemd/system/webitel-engine.service type=config
         
 
       scripts: |
-        preinstall: deploy/debian/preinst.sh
         postinstall: deploy/debian/postinst.sh
         preremove: deploy/debian/prerm.sh
+        postremove: deploy/debian/postrm.sh
         

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -59,14 +59,14 @@ jobs:
       package-name: webitel-engine
       package-description: ${{ github.event.repository.description }}
       package-contents: |
-        src=deploy/systemd/${{ vars.SERVICE_NAME }}.service dst=/etc/systemd/system/${{ vars.SERVICE_NAME }}.service type=config
+        src=deploy/systemd/webitel-engine.service dst=/etc/systemd/system/webitel-engine.service type=config
         
 
       package-depends: 
       scripts: |
-        preinstall: deploy/debian/preinst.sh
         postinstall: deploy/debian/postinst.sh
         preremove: deploy/debian/prerm.sh
+        postremove: deploy/debian/postrm.sh
         
 
   deploy:

--- a/deploy/debian/postinst.sh
+++ b/deploy/debian/postinst.sh
@@ -1,11 +1,32 @@
 #!/bin/bash
+#
+# Generic Debian postinst for Webitel Go services.
+#
+# Managed centrally in webitel/reusable-configs and synced verbatim into each
+# service repo at deploy/debian/postinst.sh — DO NOT edit per-repo.
+#
+# It is service-agnostic:
+#   * the systemd units to manage are discovered at runtime from the package
+#     itself, so it works for single- and multi-unit packages alike;
+#   * service-specific setup (e.g. creating data dirs or certificates) is
+#     provided by the package as drop-in hooks (see run_postinst_hooks).
 
 set -e
 
-SERVICE_NAME="webitel-engine"
-
 USER_NAME="webitel"
 GROUP_NAME="webitel"
+
+have_systemctl() {
+    command -v systemctl >/dev/null 2>&1
+}
+
+# systemd unit files shipped by THIS package, as basenames
+# (e.g. "webitel-engine.service"). Empty if the package ships no units.
+package_units() {
+    dpkg-query -L "$DPKG_MAINTSCRIPT_PACKAGE" 2>/dev/null \
+        | grep -E '/systemd/system/[^/]+\.service$' \
+        | sed 's:.*/::'
+}
 
 create_user() {
     if ! getent group "$GROUP_NAME" >/dev/null 2>&1; then
@@ -18,36 +39,65 @@ create_user() {
         adduser --system --no-create-home --ingroup "$GROUP_NAME" \
                 --disabled-password --disabled-login \
                 --shell /bin/false \
-                --gecos "$PACKAGE_NAME service user" \
+                --gecos "Webitel service user" \
                 "$USER_NAME"
     fi
 }
 
-configure_systemd() {
-    systemctl daemon-reload
-    systemctl enable "$SERVICE_NAME.service"
+# Run service-specific setup shipped by the package, BEFORE any unit is
+# enabled or started. Hooks are sourced (they see the script's environment)
+# and run under `set -e`: a failing hook aborts the install, which is the
+# correct behaviour when e.g. a required certificate cannot be generated.
+run_postinst_hooks() {
+    local hook_dir="/usr/lib/$DPKG_MAINTSCRIPT_PACKAGE/deb/postinst.d"
+    [ -d "$hook_dir" ] || return 0
 
-    echo "Service $SERVICE_NAME has been installed and enabled."
+    local hook
+    for hook in "$hook_dir"/*; do
+        [ -f "$hook" ] || continue
+        echo "Running postinst hook: $hook"
+        # shellcheck disable=SC1090
+        . "$hook"
+    done
 }
 
-handle_service_restart() {
-    echo "Restarting $SERVICE_NAME..."
-    systemctl restart "$SERVICE_NAME" || true
-}
+if [ "$1" = "configure" ]; then
+    echo "Configuring $DPKG_MAINTSCRIPT_PACKAGE..."
 
-if [ "$1" == "configure" ]; then
-    echo "Configuring $SERVICE_NAME..."
+    create_user
+    run_postinst_hooks
 
-    if [ -z "$2" ]; then
-        create_user
-        configure_systemd
+    if have_systemctl; then
+        systemctl daemon-reload
 
-        echo "$SERVICE_NAME installation completed successfully!"
-        echo ""
-        echo "Next steps:"
-        echo "1. Check status: sudo systemctl status $SERVICE_NAME"
-        echo "2. View logs: sudo journalctl -u $SERVICE_NAME -f"
+        units=$(package_units)
+
+        if [ -z "$2" ]; then
+            # Fresh install: enable units for boot but do NOT start them.
+            # The shipped configuration usually contains placeholder values,
+            # so the operator must review it before the first start.
+            for unit in $units; do
+                systemctl enable "$unit" || true
+            done
+
+            echo "$DPKG_MAINTSCRIPT_PACKAGE installed and enabled (not started)."
+            if [ -n "$units" ]; then
+                echo ""
+                echo "Next steps:"
+                echo "1. Review configuration under /etc/systemd/system/ and /etc/default/"
+                echo "2. Start:  sudo systemctl start $units"
+                echo "3. Status: sudo systemctl status $units"
+            fi
+        else
+            # Upgrade: restart only units that were running, so a deliberately
+            # stopped service stays stopped while a running one picks up the
+            # new binary.
+            for unit in $units; do
+                echo "Restarting $unit (if running)..."
+                systemctl try-restart "$unit" || true
+            done
+        fi
     fi
-
-    handle_service_restart
 fi
+
+exit 0

--- a/deploy/debian/postrm.sh
+++ b/deploy/debian/postrm.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+#
+# Generic Debian postrm for Webitel Go services.
+#
+# Managed centrally in webitel/reusable-configs and synced verbatim into each
+# service repo at deploy/debian/postrm.sh — DO NOT edit per-repo.
+#
+# After the unit files have been removed from disk, tell systemd to forget
+# them and clear any leftover failed state. Service data (e.g. storage
+# recordings/certificates) is intentionally NOT removed on purge.
+
+set -e
+
+have_systemctl() {
+    command -v systemctl >/dev/null 2>&1
+}
+
+# systemd unit files recorded for THIS package, as basenames. dpkg still
+# knows the file list at postrm/remove time even though the files are gone.
+package_units() {
+    dpkg-query -L "$DPKG_MAINTSCRIPT_PACKAGE" 2>/dev/null \
+        | grep -E '/systemd/system/[^/]+\.service$' \
+        | sed 's:.*/::'
+}
+
+if [ "$1" = "remove" ]; then
+    if have_systemctl; then
+        systemctl daemon-reload || true
+
+        for unit in $(package_units); do
+            systemctl reset-failed "$unit" 2>/dev/null || true
+        done
+    fi
+fi
+
+exit 0

--- a/deploy/debian/prerm.sh
+++ b/deploy/debian/prerm.sh
@@ -1,69 +1,64 @@
 #!/bin/bash
+#
+# Generic Debian prerm for Webitel Go services.
+#
+# Managed centrally in webitel/reusable-configs and synced verbatim into each
+# service repo at deploy/debian/prerm.sh — DO NOT edit per-repo.
+#
+# Stops (and, on full removal, disables) every systemd unit shipped by the
+# package. Units are discovered at runtime, so this works for single- and
+# multi-unit packages alike.
 
 set -e
 
-SERVICE_NAME="webitel-engine"
-
-stop_service() {
-    if [ -x "/bin/systemctl" ]; then
-        if systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
-            echo "Stopping $SERVICE_NAME service..."
-            systemctl stop "$SERVICE_NAME" || true
-
-            # Wait for service to stop completely
-            local timeout=10
-            local count=0
-            while systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null && [ $count -lt $timeout ]; do
-                sleep 1
-                count=$((count + 1))
-            done
-
-            if systemctl is-active --quiet "$SERVICE_NAME" 2>/dev/null; then
-                echo "Warning: Service $SERVICE_NAME did not stop gracefully within ${timeout}s" >&2
-
-                # Force kill if still running
-                systemctl kill --signal=SIGKILL "$SERVICE_NAME" || true
-            else
-                echo "Service $SERVICE_NAME stopped successfully."
-            fi
-        fi
-    fi
+have_systemctl() {
+    command -v systemctl >/dev/null 2>&1
 }
 
-disable_service() {
-    if [ -x "/bin/systemctl" ]; then
-        if systemctl is-enabled --quiet "$SERVICE_NAME" 2>/dev/null; then
-            echo "Disabling $SERVICE_NAME service..."
+# systemd unit files shipped by THIS package, as basenames.
+package_units() {
+    dpkg-query -L "$DPKG_MAINTSCRIPT_PACKAGE" 2>/dev/null \
+        | grep -E '/systemd/system/[^/]+\.service$' \
+        | sed 's:.*/::'
+}
 
-            systemctl disable "$SERVICE_NAME" || true
-            systemctl daemon-reload
+stop_units() {
+    have_systemctl || return 0
+
+    local unit
+    for unit in $(package_units); do
+        if systemctl is-active --quiet "$unit" 2>/dev/null; then
+            echo "Stopping $unit..."
+            # systemctl stop is synchronous and enforces the unit's
+            # TimeoutStopSec (escalating to SIGKILL) on its own.
+            systemctl stop "$unit" || true
         fi
-    fi
+    done
+}
+
+disable_units() {
+    have_systemctl || return 0
+
+    local unit
+    for unit in $(package_units); do
+        if systemctl is-enabled --quiet "$unit" 2>/dev/null; then
+            echo "Disabling $unit..."
+            systemctl disable "$unit" || true
+        fi
+    done
 }
 
 case "$1" in
     remove)
-        echo "Preparing to remove $SERVICE_NAME..."
-
-        stop_service
-        disable_service
-
-        echo "Service $SERVICE_NAME has been stopped and disabled."
+        echo "Removing $DPKG_MAINTSCRIPT_PACKAGE..."
+        stop_units
+        disable_units
         ;;
 
-    deconfigure)
-        echo "Deconfiguring $PACKAGE_NAME due to dependency issues..."
-
-        # Stop service but don't disable it
-        stop_service
+    deconfigure|failed-upgrade)
+        # Stop but keep the unit enabled.
+        stop_units
         ;;
-
-    failed-upgrade)
-        echo "Upgrade failed, stopping service..."
-
-        stop_service
-        ;;
-
 esac
 
 exit 0


### PR DESCRIPTION
Backports the centralized Debian maintainer scripts + packaging changes from main to v26.04:
- deploy/debian: generic postinst/prerm + new postrm (multi-unit, drop-in hooks)
- workflows: scripts block (postremove, no preinstall), literal package/service names

Files taken verbatim from main (scoped diff confirmed = only these changes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)