### PR TITLE
chore: ship .env.example on v26.04

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -52,6 +52,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-engine.service dst=/etc/systemd/system/webitel-engine.service type=config
+        src=.env.example dst=/etc/default/webitel-engine type=config
         
 
       scripts: |

--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -60,6 +60,7 @@ jobs:
       package-description: ${{ github.event.repository.description }}
       package-contents: |
         src=deploy/systemd/webitel-engine.service dst=/etc/systemd/system/webitel-engine.service type=config
+        src=.env.example dst=/etc/default/webitel-engine type=config
         
 
       package-depends: 


### PR DESCRIPTION
Adds the .env.example package-contents line to the v26.04 workflow (follow-up to the file/scripts backport). engine already has .env.example in-repo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)