### PR TITLE
fix(systemd): add missing LogsDirectory

### DIFF
--- a/deploy/systemd/webitel-engine.service
+++ b/deploy/systemd/webitel-engine.service
@@ -8,6 +8,7 @@ StartLimitBurst=3
 Type=simple
 User=webitel
 Group=webitel
+LogsDirectory=webitel
 SupplementaryGroups=freeswitch
 
 EnvironmentFile=/etc/default/webitel-engine


### PR DESCRIPTION
`LogsDirectory=webitel` was dropped from this unit during the earlier hardening merge. Restore it so systemd provisions a writable `/var/log/webitel` for the service (consistent with the other units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)