### PR TITLE
feat(deb): create i18n dir in postinst

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ CONFIG_FILE=
 
 # Location of the pre-signed certificate
 PRESIGNED_CERT=/opt/storage/key.pem
-TRANSLATION_DIRECTORY=i18n
+TRANSLATION_DIRECTORY=/usr/share/webitel/engine/i18n
 AUTH_CACHE_EXPIRE=30
 
 # Public hostname

--- a/deploy/debian/postinst.d/10-engine.sh
+++ b/deploy/debian/postinst.d/10-engine.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+#
+# Engine-specific postinst setup.
+#
+# Run by the generic Debian postinst (webitel/reusable-configs) BEFORE any
+# unit is started. Sourced under `set -e`, so a failure aborts the install.
+
+I18N_DIR=/usr/share/webitel/engine/i18n
+[ -d "$I18N_DIR" ] || install -d -o webitel -g webitel -m 0755 "$I18N_DIR"


### PR DESCRIPTION
Create the translations directory (`/usr/share/webitel/<svc>/i18n`) via a postinst `install -d` hook (create-if-missing) and point `TRANSLATION_DIRECTORY` at it — the service refuses to start without the directory.

Directories are created at install time (not via systemd-tmpfiles): no per-boot re-touch, no cleanup-timer risk to data dirs.

> Note: package build stays red until the matching reusable-configs `sync.yml` change (ship `postinst.d/`) is merged and re-synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)