### PR TITLE
[WTEL-9791]feature(agent): rm progressive_count obligattory

### DIFF
--- a/grpc_api/cc_agent.go
+++ b/grpc_api/cc_agent.go
@@ -37,6 +37,12 @@ func (api *agent) CreateAgent(ctx context.Context, in *engine.CreateAgentRequest
 		return nil, api.app.MakePermissionError(session, permission, auth_manager.PERMISSION_ACCESS_CREATE)
 	}
 
+	var progressiveCount *int
+	if in.GetProgressiveCount() > 0 {
+		reference := int(in.GetProgressiveCount())
+		progressiveCount = &reference
+	}
+
 	agent := &model.Agent{
 		DomainRecord: model.DomainRecord{
 			DomainId:  session.Domain(in.GetDomainId()),
@@ -53,7 +59,7 @@ func (api *agent) CreateAgent(ctx context.Context, in *engine.CreateAgentRequest
 			Id: int(in.GetUser().GetId()),
 		},
 		Description:      in.Description,
-		ProgressiveCount: int(in.ProgressiveCount),
+		ProgressiveCount: progressiveCount,
 		GreetingMedia:    GetLookup(in.GreetingMedia),
 		AllowChannels:    in.AllowChannels,
 		ChatCount:        in.ChatCount,
@@ -206,6 +212,12 @@ func (api *agent) UpdateAgent(ctx context.Context, in *engine.UpdateAgentRequest
 
 	var agent *model.Agent
 
+	var progressiveCallCount *int
+	if in.GetProgressiveCount() > 0 {
+		reference := int(in.GetProgressiveCount())
+		progressiveCallCount = &reference
+	}
+
 	agent, err = api.app.UpdateAgent(ctx, &model.Agent{
 		DomainRecord: model.DomainRecord{
 			Id:        in.Id,
@@ -219,7 +231,7 @@ func (api *agent) UpdateAgent(ctx context.Context, in *engine.UpdateAgentRequest
 			Id: int(in.GetUser().GetId()),
 		},
 		Description:      in.Description,
-		ProgressiveCount: int(in.ProgressiveCount),
+		ProgressiveCount: progressiveCallCount,
 		GreetingMedia:    GetLookup(in.GreetingMedia),
 		AllowChannels:    in.AllowChannels,
 		ChatCount:        in.ChatCount,
@@ -465,7 +477,7 @@ func (api *agent) SearchAgentInQueue(ctx context.Context, in *engine.SearchAgent
 				Offline: v.Agents.Offline,
 				Free:    v.Agents.Free,
 				Total:   v.Agents.Total,
-				Busy: v.Agents.Busy,
+				Busy:    v.Agents.Busy,
 			},
 		}
 
@@ -877,6 +889,11 @@ func (api *agent) SearchAgentStatusStatisticItem(ctx context.Context, in *engine
 		return nil, err
 	}
 
+	var progressiveCount uint32
+	if item.ProgressiveCount != nil {
+		progressiveCount = *item.ProgressiveCount
+	}
+
 	return &engine.AgentStatusStatisticItem{
 		AgentId:          item.AgentId,
 		Name:             item.Name,
@@ -888,7 +905,7 @@ func (api *agent) SearchAgentStatusStatisticItem(ctx context.Context, in *engine
 		Supervisor:       GetProtoLookups(item.Supervisor),
 		Auditor:          GetProtoLookups(item.Auditor),
 		Region:           GetProtoLookup(item.Region),
-		ProgressiveCount: item.ProgressiveCount,
+		ProgressiveCount: progressiveCount,
 		ChatCount:        item.ChatCount,
 		PauseCause:       item.PauseCause,
 		Online:           item.Online,
@@ -1016,7 +1033,6 @@ func transformAgent(src *model.Agent) *engine.Agent {
 		Status:                src.Status,
 		Description:           src.Description,
 		LastStatusChange:      src.LastStatusChange,
-		ProgressiveCount:      int32(src.ProgressiveCount),
 		Name:                  src.Name,
 		StatusDuration:        src.StatusDuration,
 		GreetingMedia:         GetProtoLookup(src.GreetingMedia),
@@ -1032,6 +1048,11 @@ func transformAgent(src *model.Agent) *engine.Agent {
 		ScreenControl:         src.ScreenControl,
 		AllowSetScreenControl: src.AllowSetScreenControl,
 	}
+
+	if src.ProgressiveCount != nil {
+		agent.ProgressiveCount = int32(*src.ProgressiveCount)
+	}
+
 	agent.Channel = make([]*engine.AgentChannel, 0, len(src.Channel))
 
 	for _, v := range src.Channel {

--- a/model/cc_agent.go
+++ b/model/cc_agent.go
@@ -25,13 +25,14 @@ type AgentChannel struct {
 
 type Agent struct {
 	DomainRecord
+
 	User                  Lookup         `json:"user" db:"user"`
 	Name                  string         `json:"name" db:"name"`
 	Status                string         `json:"status" db:"status"`
 	LastStatusChange      int64          `json:"last_status_change" db:"last_status_change"`
 	StatusDuration        int64          `json:"status_duration" db:"status_duration"`
 	Description           string         `json:"description" db:"description"`
-	ProgressiveCount      int            `json:"progressive_count" db:"progressive_count"`
+	ProgressiveCount      *int           `json:"progressive_count" db:"progressive_count"`
 	Channel               []AgentChannel `json:"channel" db:"channel"`
 	GreetingMedia         *Lookup        `json:"greeting_media" db:"greeting_media"`
 	AllowChannels         StringArray    `json:"allow_channels" db:"allow_channels"`
@@ -112,7 +113,7 @@ type SupervisorAgentItem struct {
 	Supervisor       []*Lookup `json:"supervisor" dlb:"supervisor"`
 	Auditor          []*Lookup `json:"auditor" db:"auditor"`
 	Region           *Lookup   `json:"region" db:"region"`
-	ProgressiveCount uint32    `json:"progressive_count" db:"progressive_count"`
+	ProgressiveCount *uint32   `json:"progressive_count" db:"progressive_count"`
 	ChatCount        uint32    `json:"chat_count" db:"chat_count"`
 
 	PauseCause    string `json:"pause_cause" db:"pause_cause"`
@@ -170,7 +171,7 @@ func (a *Agent) Patch(patch *AgentPatch) {
 	}
 
 	if patch.ProgressiveCount != nil {
-		a.ProgressiveCount = *patch.ProgressiveCount
+		a.ProgressiveCount = patch.ProgressiveCount
 	}
 
 	if patch.GreetingMedia != nil {
@@ -393,9 +394,11 @@ func (a *Agent) IsValid() AppError {
 	if a.ChatCount < 1 {
 		return NewBadRequestError("model.Agent.valid.ChatCount", "The chat count should be more or equal 1")
 	}
-	if a.ProgressiveCount < 1 {
+
+	if a.ProgressiveCount != nil && *a.ProgressiveCount < 1 {
 		return NewBadRequestError("model.Agent.valid.ProgressiveCount", "The call count should be more or equal 1")
 	}
+
 	return nil //TODO
 }
 

--- a/model/cc_queue.go
+++ b/model/cc_queue.go
@@ -1,12 +1,23 @@
 package model
 
-const (
-	QueueTypeInboundCall = 1
-	QueueTypeInboundChat = 6
+import (
+	"fmt"
+	"maps"
+	"strconv"
 )
+
+const (
+	QueueTypeInboundCall     int8 = 1
+	QueueTypeProgressiveCall int8 = 4
+	QueueTypePredictCall     int8 = 5
+	QueueTypeInboundChat     int8 = 6
+)
+
+const QueuePayloadProgressiveCountKey string = "progressive_count"
 
 type Queue struct {
 	DomainRecord
+
 	Strategy             string          `json:"strategy" db:"strategy"`
 	Enabled              bool            `json:"enabled" db:"enabled"`
 	Payload              StringInterface `json:"payload" db:"payload"`
@@ -202,9 +213,8 @@ func (q *Queue) Patch(p *QueuePatch) {
 		if q.Payload == nil {
 			q.Payload = StringInterface{}
 		}
-		for k, v := range p.Payload {
-			q.Payload[k] = v
-		}
+
+		maps.Copy(q.Payload, p.Payload)
 	}
 
 	if p.Calendar != nil {
@@ -300,7 +310,35 @@ func (q *Queue) IsValid() AppError {
 	if q.Calendar == nil && !(q.Type == QueueTypeInboundCall || q.Type == QueueTypeInboundChat) {
 		return NewBadRequestError("model.queue.valid.calendar", "Calendar is required")
 	}
-	//FIXME
+
+	if q.Type == QueueTypePredictCall || q.Type == QueueTypeProgressiveCall {
+		progressiveCountValue, exists := q.Payload[QueuePayloadProgressiveCountKey]
+		if !exists {
+			return NewBadRequestError("model.queue.valid.progressive_count_not_exist", "Progressive count is required for progressive and predictive queues")
+		}
+
+		var progessiveCount int
+		switch r := progressiveCountValue.(type) {
+		case int:
+			progessiveCount = r
+		case string:
+			parsed, err := strconv.Atoi(r)
+			if err != nil {
+				return NewBadRequestError("model.queue.valid.progressive_count_unconvertable_from_string", err.Error())
+			}
+
+			progessiveCount = parsed
+		default:
+			return NewBadRequestError("model.queue.valid.unsupported_type", fmt.Sprintf("Received unsupported type for progressive count: %T", r))
+		}
+
+		if progessiveCount <= 0 {
+			return NewBadRequestError("model.queue.valid.progressive_count_must_be_gt_zero", "Progressive count must be greater than zero")
+		}
+
+		q.Payload[QueuePayloadProgressiveCountKey] = progessiveCount
+	}
+
 	return nil
 }
 

--- a/model/cc_queue_test.go
+++ b/model/cc_queue_test.go
@@ -1,0 +1,146 @@
+package model_test
+
+import (
+	"testing"
+
+	"github.com/webitel/engine/model"
+)
+
+func TestQueue_IsValid_ProgressiveCountValidation(t *testing.T) {
+	t.Parallel()
+
+	validCalendar := &model.Lookup{Id: 1}
+
+	tests := []struct {
+		name    string
+		queue   model.Queue
+		wantErr bool
+		errID   string
+	}{
+		{
+			name: "predictive queue valid progressive count int",
+			queue: model.Queue{
+				Type:     model.QueueTypePredictCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: 5,
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "progressive queue valid progressive count string",
+			queue: model.Queue{
+				Type:     model.QueueTypeProgressiveCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: "10",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "progressive count does not exist",
+			queue: model.Queue{
+				Type:     model.QueueTypePredictCall,
+				Calendar: validCalendar,
+				Payload:  model.StringInterface{},
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.progressive_count_not_exist",
+		},
+		{
+			name: "progressive count invalid string",
+			queue: model.Queue{
+				Type:     model.QueueTypeProgressiveCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: "abc",
+				},
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.progressive_count_unconvertable_from_string",
+		},
+		{
+			name: "progressive count unsupported type",
+			queue: model.Queue{
+				Type:     model.QueueTypePredictCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: true,
+				},
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.unsupported_type",
+		},
+		{
+			name: "progressive count zero",
+			queue: model.Queue{
+				Type:     model.QueueTypeProgressiveCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: 0,
+				},
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.progressive_count_must_be_gt_zero",
+		},
+		{
+			name: "progressive count negative",
+			queue: model.Queue{
+				Type:     model.QueueTypePredictCall,
+				Calendar: validCalendar,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: -5,
+				},
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.progressive_count_must_be_gt_zero",
+		},
+		{
+			name: "non progressive queue skips validation",
+			queue: model.Queue{
+				Type:     model.QueueTypeInboundCall,
+				Calendar: nil,
+				Payload: model.StringInterface{
+					model.QueuePayloadProgressiveCountKey: "invalid",
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "nil payload for predictive queue",
+			queue: model.Queue{
+				Type:     model.QueueTypePredictCall,
+				Calendar: validCalendar,
+				Payload:  nil,
+			},
+			wantErr: true,
+			errID:   "model.queue.valid.progressive_count_not_exist",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := tt.queue.IsValid()
+
+			if tt.wantErr {
+				if got == nil {
+					t.Fatalf("expected error, got nil")
+				}
+
+				if got.GetId() != tt.errID {
+					t.Fatalf("unexpected error id: got %s, want %s", got.GetId(), tt.errID)
+				}
+
+				return
+			}
+
+			if got != nil {
+				t.Fatalf("expected nil error, got %v", got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
- add `progressive_count` support for queue.payload field with coresponding validation
- remove `progressive_count` obligattory from agent entity and supervisor agent response