### PR TITLE
[WTEL-9928]refactor(call_store): more AMD result filter options

### DIFF
--- a/model/call.go
+++ b/model/call.go
@@ -791,7 +791,7 @@ func (m *CallPayload) Has(name string) bool {
 func (m *CallPayload) StringValue(s ...string) string {
 	var mm any = m
 
-	for i := 0; i < len(s); i++ {
+	for i := range s {
 		switch vv := mm.(type) {
 		case string:
 			return vv

--- a/model/search_list.go
+++ b/model/search_list.go
@@ -61,9 +61,9 @@ func GetBetweenTo(src *FilterBetween) *int64 {
 	return nil
 }
 
-func (l *ListRequest) RemoveLastElemIfNeed(slicePtr interface{}) {
+func (l *ListRequest) RemoveLastElemIfNeed(slicePtr any) {
 	s := reflect.ValueOf(slicePtr)
-	if s.Kind() != reflect.Ptr || s.Type().Elem().Kind() != reflect.Slice {
+	if s.Kind() != reflect.Pointer || s.Type().Elem().Kind() != reflect.Slice {
 		panic(fmt.Errorf("first argument to Remove must be pointer to slice, not %T", slicePtr))
 	}
 	if s.IsNil() {
@@ -89,7 +89,6 @@ func (l *ListRequest) EndOfList() bool {
 }
 
 func (l *ListRequest) GetQ() *string {
-
 	return ReplaceWebSearch(l.Q)
 }
 
@@ -117,7 +116,7 @@ func ExtractSearchOptions(t Searcher) ListRequest {
 		res.Page = int(t.GetPage())
 	}
 	if t.GetQ() != "" {
-		res.Q = strings.Replace(t.GetQ(), "*", "%", -1)
+		res.Q = strings.ReplaceAll(t.GetQ(), "*", "%")
 
 	}
 	if s := t.GetFields(); len(s) != 0 {
@@ -154,6 +153,9 @@ var amdResultAliases = map[string][]string{
 	"VOICEMAIL": {"VOICEMAIL", "voicemail"},
 	"RINGING":   {"RINGING", "ringback"},
 	"TIMEOUT":   {"TIMEOUT", "timeout"},
+	"UNDEFINED": {"undefined"},
+	"NO ANSWER": {"no_answer"},
+	"EMPTY":     {""},
 }
 
 func ExpandAmdResult(values []string) []string {
@@ -182,9 +184,7 @@ func ExpandAmdResult(values []string) []string {
 	return out
 }
 
-func (l *ListRequest) GetRegExpQ() *string {
-	return GetRegExpQ(l.Q)
-}
+func (l *ListRequest) GetRegExpQ() *string { return GetRegExpQ(l.Q) }
 
 func GetRegExpQ(q string) *string {
 	if q != "" {

--- a/store/sqlstore/call_store.go
+++ b/store/sqlstore/call_store.go
@@ -380,7 +380,15 @@ func (s SqlCallStore) GetHistory(ctx context.Context, domainId int64, search *mo
 		and (:Ids::uuid[] isnull or id = any(:Ids))
 		and (:TransferFromIds::uuid[] isnull or transfer_from = any(:TransferFromIds))
 		and (:TransferToIds::uuid[] isnull or transfer_to = any(:TransferToIds))
-		and (:AmdResult::varchar[] isnull or amd_result = any(:AmdResult::varchar[]) or amd_ai_result = any(:AmdResult::varchar[]))
+		and (
+			:AmdResult::varchar[] isnull
+			or amd_result = any(:AmdResult::varchar[])
+			or amd_ai_result = any(:AmdResult::varchar[])
+			or (
+				''=any(:AmdResult::varchar[])
+				and (amd_result is null or amd_ai_result is null)
+			)
+		)
 		and (:QueueIds::int[] isnull or (queue_id = any(:QueueIds) or queue_ids && :QueueIds::int[]) )
 		and (:TeamIds::int[] isnull or (team_id = any(:TeamIds) or team_ids && :TeamIds::int[]) )
 		and (:AgentIds::int[] isnull or ( agent_ids && :AgentIds::int[]) )
@@ -594,7 +602,15 @@ func (s SqlCallStore) GetHistoryByGroups(ctx context.Context, domainId, userSupe
 	and (:Ids::uuid[] isnull or id = any(:Ids))
 	and (:TransferFromIds::uuid[] isnull or transfer_from = any(:TransferFromIds))
 	and (:TransferToIds::uuid[] isnull or transfer_to = any(:TransferToIds))
-	and (:AmdResult::varchar[] isnull or amd_result = any(:AmdResult::varchar[]) or amd_ai_result = any(:AmdResult::varchar[]))
+	and (
+		:AmdResult::varchar[] isnull
+		or amd_result = any(:AmdResult::varchar[])
+		or amd_ai_result = any(:AmdResult::varchar[])
+		or (
+			''=any(:AmdResult::varchar[])
+			and (amd_result is null or amd_ai_result is null)
+		)
+	)
 	and (:QueueIds::int[] isnull or (queue_id = any(:QueueIds) or queue_ids && :QueueIds::int[]) )
 	and (:TeamIds::int[] isnull or (team_id = any(:TeamIds) or team_ids && :TeamIds::int[]) )
 	and (:AgentIds::int[] isnull or ( agent_ids && :AgentIds::int[]) )


### PR DESCRIPTION
- add 'UNDEFIND', 'NO ANSWER' and 'EMPTY' AMD result options to already existend
- change AMD result filter query for GetHistory and GetHistoryByGroups repository methods