### PR TITLE
refactor(version): inject CurrentVersion via ldflags

### DIFF
--- a/model/version.go
+++ b/model/version.go
@@ -2,33 +2,8 @@ package model
 
 import "strconv"
 
-var versions = []string{
-	"26.04",
-	"26.02",
-	"25.12",
-	"25.10",
-	"25.08",
-	"25.05",
-	"25.04",
-	"25.02",
-	"24.10",
-	"24.08",
-	"24.04",
-	"24.02",
-	"23.12",
-	"23.09",
-	"23.07",
-	"23.05",
-	"23.02",
-	"22.12",
-	"22.09",
-	"22.07",
-	"22.05",
-	"2019.0.0",
-}
-
 var (
-	CurrentVersion string = versions[0]
+	CurrentVersion string = "dev"
 	BuildNumber    string
 )
 


### PR DESCRIPTION
## What
Drop the hardcoded `versions[]` slice in `model/version.go`; `CurrentVersion` now defaults to `"dev"` and is injected at build time via `-ldflags`:

```
-X github.com/webitel/engine/model.CurrentVersion=<version>
```

`BuildNumber` and `BuildNumberInt()` are unchanged.

## Why
Removes the need to manually bump the version slice each release — the version comes from the build pipeline (branch/tag), consistent with `BuildNumber` injection.

## Notes
- Workflow ldflags injection is handled separately (reusable-configs), so no workflow files are touched here.
- `"dev"` remains the fallback for local builds and tests.