### PR TITLE
fix(buf): track protos main branch on main

### DIFF
--- a/buf/buf.gen.cc.yaml
+++ b/buf/buf.gen.cc.yaml
@@ -22,5 +22,5 @@ plugins:
 inputs:
 #  - directory: "../protos/cc"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: cc

--- a/buf/buf.gen.flow.yaml
+++ b/buf/buf.gen.flow.yaml
@@ -26,5 +26,5 @@ plugins:
 inputs:
 #  - directory: "../protos/workflow"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: workflow

--- a/buf/buf.gen.fs.yaml
+++ b/buf/buf.gen.fs.yaml
@@ -15,5 +15,5 @@ plugins:
 inputs:
 #  - directory: "../protos/fs"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: fs

--- a/buf/buf.gen.logger.yaml
+++ b/buf/buf.gen.logger.yaml
@@ -15,5 +15,5 @@ plugins:
 inputs:
 #  - directory: "../protos/logger"
   - git_repo: "https://github.com/webitel/protos"
-    branch: "v26.02"
+    branch: "main"
     subdir: logger


### PR DESCRIPTION
## What
Point the drifted `buf/*.yaml` proto inputs back at `github.com/webitel/protos` **main** on the `main` branch. They were stuck on `branch: "v26.02"`.

| File | Was | Now |
|------|-----|-----|
| buf/buf.gen.cc.yaml | v26.02 | main |
| buf/buf.gen.flow.yaml | v26.02 | main |
| buf/buf.gen.fs.yaml | v26.02 | main |
| buf/buf.gen.logger.yaml | v26.02 | main |

## Why
On `main`, buf must track protos `main`; pinning to a release branch belongs only on release branches. `buf/buf.gen.yaml` and everything under `pkg/wbt/buf/` were already on `main` — this aligns the remaining four.

## Note
Config-only change; no generated code is regenerated here.